### PR TITLE
Enforce array dimensions to avoid vector conversion

### DIFF
--- a/R-package/quantgen/R/quantile_ensemble.R
+++ b/R-package/quantgen/R/quantile_ensemble.R
@@ -438,7 +438,7 @@ predict.quantile_ensemble = function(object, newq, s=NULL, sort=TRUE, iso=FALSE,
   z = matrix(NA, nrow=n0, ncol=r)
   alpha = matrix(object$alpha, nrow=p, ncol=r)
   for (i in 1:n0) {
-    mat = t(newq[i,,]) %*% alpha
+    mat = t(`dim<-`(newq[i, , ], apply(newq, 1, dim)[, 1])) %*% alpha
     if (r == 1) z[i,] = mat
     else z[i,] = diag(mat)
   }


### PR DESCRIPTION
Currently an error is thrown if `quantile_ensemble` is called and the number of ensemble components is 1 because of an automatic array-to-vector conversion done by R. This is a fix that enforces array dimensions.