### PR TITLE
Fix quantile_lasso() when p = 1.

### DIFF
--- a/quantgen/R/quantile_genlasso.R
+++ b/quantgen/R/quantile_genlasso.R
@@ -532,7 +532,7 @@ get_lambda_max = function(x, y, d, weights=NULL, lp_solver=c("glpk","gurobi")) {
   o = which(apply(d, 2, function(v) all(abs(v) <= sqrt(.Machine$double.eps))))
   if (length(o) > 0) {
     d = d[,-o]
-    x = x[,-o]
+    x = x[,-o,drop=FALSE]
     p = p - length(o)
   }
 

--- a/quantgen/R/utils.R
+++ b/quantgen/R/utils.R
@@ -51,7 +51,7 @@ setup_xyd = function(x, y, d, weights=NULL, intercept=TRUE, standardize=TRUE,
   
   # Remove NA values present in x or y
   good_inds = rowSums(is.na(x)) == 0 & !is.na(y)
-  x = x[good_inds,]
+  x = x[good_inds,,drop=FALSE]
   y = y[good_inds]
   n = sum(good_inds)
 


### PR DESCRIPTION
Fix quantile_lasso() when a single predictor is given (i.e., when dim(x)=c(n, 1)).

Without the fix, the subset operation of line 54 in utils.R drops the second dimension of x when x only has one column, incurring an error at line 64 (as x would now be a vector but apply() expects a matrix).

Minimum reproducing example for the issue (fix was small enough that I didn't bother filing a formal one):

```
> library(quantgen)
> set.seed(1)
> n = 50
> p = 1
> beta = 5 + rnorm(p)
> beta0 = 10 + rnorm(1)
> X = matrix(rnorm(p*n), ncol=p)
> y = X%*%beta + beta0 + rnorm(n)
> tau = c(0.05, 0.5, 0.95)
> quantgen::quantile_lasso(X, y, tau=tau, lambda=0)
Error in apply(x, 2, mean) : dim(X) must have a positive length
```